### PR TITLE
move configuration constants into separate class and make public

### DIFF
--- a/java/kudu-mapreduce/src/main/java/org/apache/kudu/mapreduce/KuduMapReduceConstants.java
+++ b/java/kudu-mapreduce/src/main/java/org/apache/kudu/mapreduce/KuduMapReduceConstants.java
@@ -1,0 +1,46 @@
+package org.apache.kudu.mapreduce;
+
+public final class KuduMapReduceConstants {
+
+  /** Job parameter that specifies the input table. */
+  public static final String INPUT_TABLE_KEY = "kudu.mapreduce.input.table";
+  /** Job parameter that specifies if the scanner should cache blocks or not (default: false). */
+  public static final String SCAN_CACHE_BLOCKS = "kudu.mapreduce.input.scan.cache.blocks";
+  /**
+   * Job parameter that specifies if the scanner should be fault tolerant
+   * or not (default: false).
+   */
+  public static final String FAULT_TOLERANT_SCAN = "kudu.mapreduce.input.fault.tolerant.scan";
+  /** Job parameter that specifies where the masters are. */
+  public static final String MASTER_ADDRESSES_KEY = "kudu.mapreduce.master.address";
+  /** Job parameter that specifies how long we wait for operations to complete (default: 10s). */
+  public static final String OPERATION_TIMEOUT_MS_KEY = "kudu.mapreduce.operation.timeout.ms";
+  /** Job parameter that specifies the address for the name server. */
+  public static final String NAME_SERVER_KEY = "kudu.mapreduce.name.server";
+  /** Job parameter that specifies the encoded column predicates (may be empty). */
+  public static final String ENCODED_PREDICATES_KEY =
+      "kudu.mapreduce.encoded.predicates";
+  /**
+   * Job parameter that specifies the column projection as a comma-separated list of column names.
+   *
+   * Not specifying this at all (i.e. setting to null) or setting to the special string
+   * '*' means to project all columns.
+   *
+   * Specifying the empty string means to project no columns (i.e just count the rows).
+   */
+  public static final String COLUMN_PROJECTION_KEY = "kudu.mapreduce.column.projection";
+  /** Job parameter that specifies the output table. */
+  public static final String OUTPUT_TABLE_KEY = "kudu.mapreduce.output.table";
+
+  /** Number of rows that are buffered before flushing to the tablet server */
+  public static final String BUFFER_ROW_COUNT_KEY = "kudu.mapreduce.buffer.row.count";
+
+  /** default value for BUFFER_ROW_COUNT_KEY */
+  public static final Integer DEFAULT_BUFFER_ROW_COUNT_KEY = 1000;
+
+  /**
+   * Job parameter that specifies which key is to be used to reach the KuduTableOutputFormat
+   * belonging to the caller
+   */
+  public static final String MULTITON_KEY = "kudu.mapreduce.multitonkey";
+}

--- a/java/kudu-mapreduce/src/main/java/org/apache/kudu/mapreduce/KuduTableMapReduceUtil.java
+++ b/java/kudu-mapreduce/src/main/java/org/apache/kudu/mapreduce/KuduTableMapReduceUtil.java
@@ -161,9 +161,9 @@ public class KuduTableMapReduceUtil {
       job.setOutputValueClass(Operation.class);
 
       Configuration conf = job.getConfiguration();
-      conf.set(KuduTableOutputFormat.MASTER_ADDRESSES_KEY, masterAddresses);
-      conf.set(KuduTableOutputFormat.OUTPUT_TABLE_KEY, table);
-      conf.setLong(KuduTableOutputFormat.OPERATION_TIMEOUT_MS_KEY, operationTimeoutMs);
+      conf.set(KuduMapReduceConstants.MASTER_ADDRESSES_KEY, masterAddresses);
+      conf.set(KuduMapReduceConstants.OUTPUT_TABLE_KEY, table);
+      conf.setLong(KuduMapReduceConstants.OPERATION_TIMEOUT_MS_KEY, operationTimeoutMs);
       if (addDependencies) {
         addDependencyJars(job);
       }
@@ -230,17 +230,17 @@ public class KuduTableMapReduceUtil {
 
       Configuration conf = job.getConfiguration();
 
-      conf.set(KuduTableInputFormat.MASTER_ADDRESSES_KEY, masterAddresses);
-      conf.set(KuduTableInputFormat.INPUT_TABLE_KEY, table);
-      conf.setLong(KuduTableInputFormat.OPERATION_TIMEOUT_MS_KEY, operationTimeoutMs);
-      conf.setBoolean(KuduTableInputFormat.SCAN_CACHE_BLOCKS, cacheBlocks);
-      conf.setBoolean(KuduTableInputFormat.FAULT_TOLERANT_SCAN, isFaultTolerant);
+      conf.set(KuduMapReduceConstants.MASTER_ADDRESSES_KEY, masterAddresses);
+      conf.set(KuduMapReduceConstants.INPUT_TABLE_KEY, table);
+      conf.setLong(KuduMapReduceConstants.OPERATION_TIMEOUT_MS_KEY, operationTimeoutMs);
+      conf.setBoolean(KuduMapReduceConstants.SCAN_CACHE_BLOCKS, cacheBlocks);
+      conf.setBoolean(KuduMapReduceConstants.FAULT_TOLERANT_SCAN, isFaultTolerant);
 
       if (columnProjection != null) {
-        conf.set(KuduTableInputFormat.COLUMN_PROJECTION_KEY, columnProjection);
+        conf.set(KuduMapReduceConstants.COLUMN_PROJECTION_KEY, columnProjection);
       }
 
-      conf.set(KuduTableInputFormat.ENCODED_PREDICATES_KEY, base64EncodePredicates(predicates));
+      conf.set(KuduMapReduceConstants.ENCODED_PREDICATES_KEY, base64EncodePredicates(predicates));
 
       if (addDependencies) {
         addDependencyJars(job);
@@ -403,7 +403,7 @@ public class KuduTableMapReduceUtil {
    */
   @SuppressWarnings("rawtypes")
   public static KuduTable getTableFromContext(TaskInputOutputContext context) {
-    String multitonKey = context.getConfiguration().get(KuduTableOutputFormat.MULTITON_KEY);
+    String multitonKey = context.getConfiguration().get(KuduMapReduceConstants.MULTITON_KEY);
     return KuduTableOutputFormat.getKuduTable(multitonKey);
   }
 

--- a/java/kudu-mapreduce/src/test/java/org/apache/kudu/mapreduce/ITKuduTableInputFormat.java
+++ b/java/kudu-mapreduce/src/test/java/org/apache/kudu/mapreduce/ITKuduTableInputFormat.java
@@ -120,14 +120,14 @@ public class ITKuduTableInputFormat extends BaseKuduTest {
         List<KuduPredicate> predicates) throws IOException, InterruptedException {
     KuduTableInputFormat input = new KuduTableInputFormat();
     Configuration conf = new Configuration();
-    conf.set(KuduTableInputFormat.MASTER_ADDRESSES_KEY, getMasterAddresses());
-    conf.set(KuduTableInputFormat.INPUT_TABLE_KEY, TABLE_NAME);
+    conf.set(KuduMapReduceConstants.MASTER_ADDRESSES_KEY, getMasterAddresses());
+    conf.set(KuduMapReduceConstants.INPUT_TABLE_KEY, TABLE_NAME);
     if (columnProjection != null) {
-      conf.set(KuduTableInputFormat.COLUMN_PROJECTION_KEY, columnProjection);
+      conf.set(KuduMapReduceConstants.COLUMN_PROJECTION_KEY, columnProjection);
     }
     if (predicates != null) {
       String encodedPredicates = KuduTableMapReduceUtil.base64EncodePredicates(predicates);
-      conf.set(KuduTableInputFormat.ENCODED_PREDICATES_KEY, encodedPredicates);
+      conf.set(KuduMapReduceConstants.ENCODED_PREDICATES_KEY, encodedPredicates);
     }
     input.setConf(conf);
     List<InputSplit> splits = input.getSplits(null);

--- a/java/kudu-mapreduce/src/test/java/org/apache/kudu/mapreduce/ITKuduTableOutputFormat.java
+++ b/java/kudu-mapreduce/src/test/java/org/apache/kudu/mapreduce/ITKuduTableOutputFormat.java
@@ -48,11 +48,11 @@ public class ITKuduTableOutputFormat extends BaseKuduTest {
 
     KuduTableOutputFormat output = new KuduTableOutputFormat();
     Configuration conf = new Configuration();
-    conf.set(KuduTableOutputFormat.MASTER_ADDRESSES_KEY, getMasterAddresses());
-    conf.set(KuduTableOutputFormat.OUTPUT_TABLE_KEY, TABLE_NAME);
+    conf.set(KuduMapReduceConstants.MASTER_ADDRESSES_KEY, getMasterAddresses());
+    conf.set(KuduMapReduceConstants.OUTPUT_TABLE_KEY, TABLE_NAME);
     output.setConf(conf);
 
-    String multitonKey = conf.get(KuduTableOutputFormat.MULTITON_KEY);
+    String multitonKey = conf.get(KuduMapReduceConstants.MULTITON_KEY);
     KuduTable table = KuduTableOutputFormat.getKuduTable(multitonKey);
     assertNotNull(table);
 


### PR DESCRIPTION
I moved the configuration constants into their own class. There were some duplicates (e.g.MASTER_ADDRESSES_KEY in both Input and Output).
I also made them public so other applications can access them (e.g. a Hive SerDe can now use those Strings instead of redefining the same configuration parameters again)

also added new Integer DEFAULT_BUFFER_ROW_COUNT_KEY to replace hardcoded int in the application code.