### PR TITLE
[tools] Describe more table attributes

### DIFF
--- a/src/kudu/cfile/cfile-test.cc
+++ b/src/kudu/cfile/cfile-test.cc
@@ -66,7 +66,6 @@
 #include "kudu/util/compression/compression.pb.h"
 #include "kudu/util/env.h"
 #include "kudu/util/int128.h"
-#include "kudu/util/int128_util.h"
 #include "kudu/util/mem_tracker.h"
 #include "kudu/util/memory/arena.h"
 #include "kudu/util/metrics.h"

--- a/src/kudu/cfile/encoding-test.cc
+++ b/src/kudu/cfile/encoding-test.cc
@@ -51,7 +51,6 @@
 #include "kudu/util/group_varint-inl.h"
 #include "kudu/util/hexdump.h"
 #include "kudu/util/int128.h"
-#include "kudu/util/int128_util.h" // IWYU pragma: keep
 #include "kudu/util/memory/arena.h"
 #include "kudu/util/random.h"
 #include "kudu/util/random_util.h"

--- a/src/kudu/common/schema.cc
+++ b/src/kudu/common/schema.cc
@@ -127,10 +127,13 @@ string ColumnSchema::ToString() const {
 string ColumnSchema::TypeToString() const {
   string type_name = type_info_->name();
   ToUpperCase(type_name, &type_name);
-  return Substitute("$0$1 $2",
+  return Substitute("$0$1 $2 $3 $4 $5",
                     type_name,
-                    type_attributes().ToStringForType(type_info()->type()),
-                    is_nullable_ ? "NULLABLE" : "NOT NULL");
+                    type_attributes_.ToStringForType(type_info_->type()),
+                    is_nullable_ ? "NULLABLE" : "NOT NULL",
+                    attributes_.ToString(),
+                    has_read_default() ? read_default_->ToString() : "-",
+                    has_write_default() ? write_default_->ToString() : "-");
 }
 
 size_t ColumnSchema::memory_footprint_excluding_this() const {

--- a/src/kudu/common/types.h
+++ b/src/kudu/common/types.h
@@ -37,6 +37,7 @@
 #include "kudu/gutil/strings/escaping.h"
 #include "kudu/gutil/strings/numbers.h"
 #include "kudu/util/int128.h"
+#include "kudu/util/int128_util.h"
 #include "kudu/util/slice.h"
 // IWYU pragma: no_include "kudu/util/status.h"
 
@@ -783,6 +784,40 @@ class Variant {
     }
     CHECK(false) << "not reached!";
     return NULL;
+  }
+
+  std::string ToString() const {
+    switch (type_) {
+      case UNKNOWN_DATA:
+        LOG(FATAL) << "Attempted to access value of unknown data type";
+      case IS_DELETED:
+      case BOOL:
+        return numeric_.b1 ? "true" : "false";
+      case INT8:         return std::to_string(numeric_.i8);
+      case UINT8:        return std::to_string(numeric_.u8);
+      case INT16:        return std::to_string(numeric_.i16);
+      case UINT16:       return std::to_string(numeric_.u16);
+      case DECIMAL32:
+      case INT32:        return std::to_string(numeric_.i32);
+      case UINT32:       return std::to_string(numeric_.u32);
+      case DECIMAL64:
+      case UNIXTIME_MICROS:
+      case INT64:        return std::to_string(numeric_.i64);
+      case UINT64:       return std::to_string(numeric_.u64);
+      case DECIMAL128:
+      case INT128: {
+        std::stringstream ss;
+        ss << numeric_.i128;
+        return ss.str();
+      }
+      case FLOAT:        return std::to_string(numeric_.float_val);
+      case DOUBLE:       return std::to_string(numeric_.double_val);
+      case STRING:
+      case BINARY:       return vstr_.ToString();
+      default: LOG(FATAL) << "Unknown data type: " << type_;
+    }
+    CHECK(false) << "not reached!";
+    return "";
   }
 
   bool Equals(const Variant *other) const {

--- a/src/kudu/tools/kudu-tool-test.cc
+++ b/src/kudu/tools/kudu-tool-test.cc
@@ -111,7 +111,6 @@
 #include "kudu/tserver/tserver_admin.proxy.h"
 #include "kudu/util/async_util.h"
 #include "kudu/util/env.h"
-#include "kudu/util/int128_util.h" // IWYU pragma: keep
 #include "kudu/util/metrics.h"
 #include "kudu/util/monotime.h"
 #include "kudu/util/net/net_util.h"


### PR DESCRIPTION
This add more attributes to describe a table, including its
encoding type, compression type, and default read/write value.
My use case of the extra information is to compare two tables
in the same or different clusters: export the full descriptions
of the two tables into texts, and then use any text compare tool
to check the difference.