### PR TITLE
[server] Add start_time in server description

### DIFF
--- a/src/kudu/common/wire_protocol.proto
+++ b/src/kudu/common/wire_protocol.proto
@@ -93,6 +93,9 @@ message ServerRegistrationPB {
   // In this case, https:// URLs should be generated for the above
   // 'http_addresses' field.
   optional bool https_enabled = 4;
+
+  // Seconds since the epoch.
+  optional int64 start_time = 5;
 }
 
 message ServerEntryPB {

--- a/src/kudu/master/master.cc
+++ b/src/kudu/master/master.cc
@@ -293,6 +293,7 @@ Status Master::InitMasterRegistration() {
     reg.set_https_enabled(web_server()->IsSecure());
   }
   reg.set_software_version(VersionInfo::GetVersionInfo());
+  reg.set_start_time(start_time_);
 
   registration_.Swap(&reg);
   registration_initialized_.store(true);

--- a/src/kudu/master/ts_descriptor-test.cc
+++ b/src/kudu/master/ts_descriptor-test.cc
@@ -67,6 +67,7 @@ void SetupBasicRegistrationInfo(const string& uuid,
   http_hostport->set_port(54321);
   registration->set_software_version("1.0.0");
   registration->set_https_enabled(false);
+  registration->set_start_time(10000);
 }
 
 TEST(TSDescriptorTest, TestRegistration) {

--- a/src/kudu/server/server_base.cc
+++ b/src/kudu/server/server_base.cc
@@ -43,6 +43,7 @@
 #include "kudu/gutil/port.h"
 #include "kudu/gutil/strings/strcat.h"
 #include "kudu/gutil/strings/substitute.h"
+#include "kudu/gutil/walltime.h"
 #include "kudu/rpc/messenger.h"
 #include "kudu/rpc/remote_user.h"
 #include "kudu/rpc/result_tracker.h"
@@ -678,6 +679,8 @@ Status ServerBase::Start() {
     RETURN_NOT_OK_PREPEND(DumpServerInfo(options_.dump_info_path, options_.dump_info_format),
                           "Failed to dump server info to " + options_.dump_info_path);
   }
+
+  start_time_ = WallTime_Now();
 
   return Status::OK();
 }

--- a/src/kudu/server/server_base.h
+++ b/src/kudu/server/server_base.h
@@ -107,6 +107,10 @@ class ServerBase {
   // Return a PB describing the status of the server (version info, bound ports, etc)
   Status GetStatusPB(ServerStatusPB* status) const;
 
+  int64_t start_time() const {
+    return start_time_;
+  }
+
   enum {
     SUPER_USER = 1,
     USER = 1 << 1,
@@ -161,6 +165,7 @@ class ServerBase {
   void LogUnauthorizedAccess(rpc::RpcContext* rpc) const;
 
   const std::string name_;
+  int64_t start_time_;
 
   std::unique_ptr<MinidumpExceptionHandler> minidump_handler_;
   std::shared_ptr<MemTracker> mem_tracker_;

--- a/src/kudu/tools/tool_action_tserver.cc
+++ b/src/kudu/tools/tool_action_tserver.cc
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#include "kudu/tools/tool_action.h"
+#include <time.h>
 
 #include <iostream>
 #include <memory>
@@ -35,10 +35,13 @@
 #include "kudu/gutil/strings/split.h"
 #include "kudu/gutil/strings/stringpiece.h"
 #include "kudu/gutil/strings/substitute.h"
+#include "kudu/gutil/walltime.h"
 #include "kudu/master/master.pb.h"
 #include "kudu/master/master.proxy.h"
+#include "kudu/tools/tool_action.h"
 #include "kudu/tools/tool_action_common.h"
 #include "kudu/tserver/tablet_server.h"
+#include "kudu/util/pb_util.h"
 #include "kudu/util/status.h"
 
 DECLARE_string(columns);
@@ -143,6 +146,10 @@ Status ListTServers(const RunnerContext& context) {
         string loc = server.location();
         values.emplace_back(loc.empty() ? "<none>" : std::move(loc));
       }
+    } else if (boost::iequals(column, "start_time")) {
+      for (const auto& server : servers) {
+        values.emplace_back(std::move(pb_util::ParseStartTime(server.registration())));
+      }
     } else {
       return Status::InvalidArgument("unknown column (--columns)", column);
     }
@@ -207,7 +214,7 @@ unique_ptr<Mode> BuildTServerMode() {
                             string("Comma-separated list of tserver info fields to "
                                    "include in output.\nPossible values: uuid, "
                                    "rpc-addresses, http-addresses, version, seqno, "
-                                   "and heartbeat"))
+                                   "heartbeat and start_time"))
       .AddOptionalParameter("format")
       .AddOptionalParameter("timeout_ms")
       .Build();

--- a/src/kudu/tserver/heartbeater.cc
+++ b/src/kudu/tserver/heartbeater.cc
@@ -369,6 +369,7 @@ Status Heartbeater::Thread::SetupRegistration(ServerRegistrationPB* reg) {
     reg->set_https_enabled(server_->web_server()->IsSecure());
   }
   reg->set_software_version(VersionInfo::GetVersionInfo());
+  reg->set_start_time(server_->start_time());
 
   return Status::OK();
 }

--- a/src/kudu/util/pb_util.cc
+++ b/src/kudu/util/pb_util.cc
@@ -649,6 +649,19 @@ string SecureShortDebugString(const Message& msg) {
   return debug_string;
 }
 
+std::string ParseStartTime(const ServerRegistrationPB& reg) {
+  string start_time;
+  if (reg.has_start_time()) {
+    // Convert epoch time to localtime.
+    StringAppendStrftime(&start_time, "%Y-%m-%d %H:%M:%S %Z",
+                         static_cast<time_t>(reg.start_time()), true);
+  } else {
+    start_time = "<unknown>";
+  }
+
+  return start_time;
+}
+
 
 WritablePBContainerFile::WritablePBContainerFile(shared_ptr<RWFile> writer)
   : state_(FileState::NOT_INITIALIZED),

--- a/src/kudu/util/pb_util.h
+++ b/src/kudu/util/pb_util.h
@@ -30,6 +30,7 @@
 #include <google/protobuf/message.h>
 #include <gtest/gtest_prod.h>
 
+#include "kudu/common/wire_protocol.pb.h"
 #include "kudu/gutil/ref_counted.h"
 #include "kudu/util/mutex.h"
 #include "kudu/util/debug/trace_event_impl.h"
@@ -115,6 +116,9 @@ std::string SecureDebugString(const google::protobuf::Message& msg);
 
 // Same as SecureDebugString() above, but equivalent to Message::ShortDebugString.
 std::string SecureShortDebugString(const google::protobuf::Message& msg);
+
+// Parse 'start_time' in ServerRegistrationPB, return localtime or '<unknown>'.
+std::string ParseStartTime(const ServerRegistrationPB& reg);
 
 // A protobuf "container" has the following format (all integers in
 // little-endian byte order).

--- a/www/masters.mustache
+++ b/www/masters.mustache
@@ -32,6 +32,7 @@ under the License.
     <thead><tr>
       <th>UUID</th>
       <th>Role</th>
+      <th>Start time</th>
       <th>Registration</th>
     </tr></thead>
     <tbody>
@@ -39,6 +40,7 @@ under the License.
       <tr>
           <td>{{#target}}<a href="{{.}}">{{/target}}{{uuid}}{{#target}}</a>{{/target}}</td>
           <td>{{role}}</td>
+          <td>{{start_time}}</td>
           <td><pre><code>{{registration}}</code></pre></td>
       </tr>
     {{/masters}}

--- a/www/tablet-servers.mustache
+++ b/www/tablet-servers.mustache
@@ -47,6 +47,7 @@ under the License.
       <th>UUID</th>
       <th>Location</th>
       <th>Time since heartbeat</th>
+      <th>Start time</th>
       <th>Registration</th>
     </tr></thead>
     <tbody>
@@ -55,6 +56,7 @@ under the License.
         <td>{{#target}}<a href="{{.}}">{{/target}}{{uuid}}{{#target}}</a>{{/target}}</td>
         <td>{{location}}</td>
         <td>{{time_since_hb}}</td>
+        <td>{{start_time}}</td>
         <td><pre><code>{{registration}}</code></pre></td>
       </tr>
     {{/live_tservers}}


### PR DESCRIPTION
Add `start_time` to describe the start time of a server in
localtime format, like `2019-01-01 00:00:00 UTC`. We can use
this information to acknowledge the last start time of a server,
both master and tserver, to check whether there is an unexpect
restarting, the server joined time, etc. We can get `start_time`
of servers from both web-ui and command line `kudu tserver/master
list`.

Change-Id: I041467014499ad00c07398ad8f61c6d6ca1ceeca