### PR TITLE
[metrics] Add a new metric 'last_consult_timestamp' for tablet

### DIFF
--- a/src/kudu/tablet/tablet_metrics.cc
+++ b/src/kudu/tablet/tablet_metrics.cc
@@ -133,6 +133,10 @@ METRIC_DEFINE_counter(tablet, mrs_lookups, "MemRowSet Lookups",
                       kudu::MetricUnit::kProbes,
                       "Number of times a MemRowSet was consulted.",
                       kudu::MetricLevel::kDebug);
+METRIC_DEFINE_gauge_uint64(tablet, last_consult_timestamp, "Last Consult Timestamp",
+                           kudu::MetricUnit::kTimestamp,
+                           "Last timestamp of writes or scans on this tablet.",
+                           kudu::MetricLevel::kDebug);
 METRIC_DEFINE_counter(tablet, bytes_flushed, "Bytes Flushed",
                       kudu::MetricUnit::kBytes,
                       "Amount of data that has been flushed to disk by this tablet.",
@@ -318,6 +322,8 @@ namespace tablet {
 
 #define MINIT(x) x(METRIC_##x.Instantiate(entity))
 #define GINIT(x) x(METRIC_##x.Instantiate(entity, 0))
+// TODO(yingchun): Should use kMax type.
+// #define MAXINIT(x) x(METRIC_##x.Instantiate(entity, 0, kMax))
 #define MEANINIT(x) x(METRIC_##x.InstantiateMeanGauge(entity))
 TabletMetrics::TabletMetrics(const scoped_refptr<MetricEntity>& entity)
   : MINIT(rows_inserted),
@@ -338,6 +344,7 @@ TabletMetrics::TabletMetrics(const scoped_refptr<MetricEntity>& entity)
     MINIT(key_file_lookups),
     MINIT(delta_file_lookups),
     MINIT(mrs_lookups),
+    GINIT(last_consult_timestamp),// TODO(yingchun): Should use MAXINIT.
     MINIT(bytes_flushed),
     MINIT(undo_delta_block_gc_bytes_deleted),
     MINIT(bloom_lookups_per_op),

--- a/src/kudu/tablet/tablet_metrics.h
+++ b/src/kudu/tablet/tablet_metrics.h
@@ -17,8 +17,8 @@
 #ifndef KUDU_TABLET_TABLET_METRICS_H
 #define KUDU_TABLET_TABLET_METRICS_H
 
+#include <cstddef>
 #include <cstdint>
-#include <stddef.h>
 
 #include "kudu/gutil/ref_counted.h"
 #include "kudu/util/metrics.h"
@@ -66,6 +66,7 @@ struct TabletMetrics {
   scoped_refptr<Counter> key_file_lookups;
   scoped_refptr<Counter> delta_file_lookups;
   scoped_refptr<Counter> mrs_lookups;
+  scoped_refptr<AtomicGauge<uint64_t>> last_consult_timestamp;
 
   // Operation stats.
   scoped_refptr<Counter> bytes_flushed;

--- a/src/kudu/util/metrics.h
+++ b/src/kudu/util/metrics.h
@@ -399,6 +399,7 @@ struct MetricUnit {
     kState,
     kSessions,
     kTablets,
+    kTimestamp,
   };
   static const char* Name(Type unit);
 };


### PR DESCRIPTION
Add a new metric 'last_consult_timestamp' for tablet to indicate the
last write or scan timestamp of the tablet. We can judge whether a
tablet is 'hot' or 'cold' by this metric.

Change-Id: I90738ba90eaa8f78c8d721dde2eed2b723d5572d