### PR TITLE
[KUDU-3054][SPARK]Init kudu.write_duration accumulator lazily

### DIFF
--- a/java/kudu-spark/src/main/scala/org/apache/kudu/spark/kudu/KuduContext.scala
+++ b/java/kudu-spark/src/main/scala/org/apache/kudu/spark/kudu/KuduContext.scala
@@ -128,8 +128,11 @@ class KuduContext(val kuduMaster: String, sc: SparkContext, val socketReadTimeou
   val timestampAccumulator = new TimestampAccumulator()
   sc.register(timestampAccumulator)
 
-  val durationHistogram = new HdrHistogramAccumulator()
-  sc.register(durationHistogram, "kudu.write_duration")
+  lazy val durationHistogram = {
+    val acc = new HdrHistogramAccumulator()
+    sc.register(acc, "kudu.write_duration")
+    acc
+  }
 
   @deprecated("Use KuduContext constructor", "1.4.0")
   def this(kuduMaster: String) {
@@ -374,6 +377,8 @@ class KuduContext(val kuduMaster: String, sc: SparkContext, val socketReadTimeou
       rdd = repartitionRows(rdd, tableName, schema, writeOptions)
     }
 
+    // materialize durationHistogram
+    durationHistogram
     // Write the rows for each Spark partition.
     rdd.foreachPartition(iterator => {
       val pendingErrors = writePartitionRows(


### PR DESCRIPTION
Currently, we encountered a issue in kudu-spark that will causing the following spark sql query failure:

```

Job aborted due to stage failure: Total size of serialized results of 942 tasks (2.0 GB) is bigger than spark.driver.maxResultSize (2.0 GB)

```

After carefully debug, we find out that it's the kudu.write_duration accumulators causing single spark task larger than 2M, thus all tasks size of the stage will bigger than the limit.

However, this stage is just reading kudu table and do shuffle exchange, no writing any kudu tables.

So I propose to init this accumulator lazily in KuduContext to avoid such issues.