### PR TITLE
[Tools] Rebuild master according to part of tables not all tables

### DIFF
--- a/src/kudu/fs/data_dirs.cc
+++ b/src/kudu/fs/data_dirs.cc
@@ -248,6 +248,7 @@ Status DataDirManager::OpenExisting(Env* env, CanonicalizedRootsList data_fs_roo
                                     unique_ptr<DataDirManager>* dd_manager) {
   unique_ptr<DataDirManager> dm;
   dm.reset(new DataDirManager(env, opts, std::move(data_fs_roots)));
+  std::cout << "wangxixu-fs_roots:" << std::endl;
   RETURN_NOT_OK(dm->Open());
   dd_manager->swap(dm);
   return Status::OK();

--- a/src/kudu/fs/fs_manager.cc
+++ b/src/kudu/fs/fs_manager.cc
@@ -619,6 +619,7 @@ Status FsManager::CreateFileSystemRoots(
     RETURN_NOT_OK_PREPEND(env_util::IsDirectoryEmpty(env_, root.path, &is_empty),
                           "unable to check if FSManager root is empty");
     if (!is_empty) {
+      std::cout << "wangxiux-not-mepyt:" << root.path << std::endl;
       non_empty_roots.emplace_back(root.path);
     }
   }

--- a/src/kudu/master/sys_catalog.cc
+++ b/src/kudu/master/sys_catalog.cc
@@ -1147,5 +1147,20 @@ void SysCatalogTable::InitLocalRaftPeerPB() {
   *local_peer_pb_.mutable_last_known_addr() = HostPortToPB(hps[0]);
 }
 
+void SimpleTableVisitor::Reset() {
+  tables.clear();
+}
+
+Status SimpleTableVisitor::VisitTable(const string& table_id,
+                                     const SysTablesEntryPB& metadata) {
+  // Setup the table info
+  scoped_refptr<TableInfo> table = new TableInfo(table_id);
+  TableMetadataLock l(table.get(), LockMode::WRITE);
+  l.mutable_data()->pb.CopyFrom(metadata);
+  l.Commit();
+  tables.emplace_back(std::move(table));
+  return Status::OK();
+}
+
 } // namespace master
 } // namespace kudu

--- a/src/kudu/master/sys_catalog.h
+++ b/src/kudu/master/sys_catalog.h
@@ -101,6 +101,16 @@ class TServerStateVisitor {
                        const SysTServerStateEntryPB& metadata) = 0;
 };
 
+class SimpleTableVisitor : public TableVisitor {
+ public:
+  void Reset();
+
+  Status VisitTable(const std::string& table_id,
+                    const SysTablesEntryPB& metadata) override;
+
+  std::vector<scoped_refptr<TableInfo>> tables;
+};
+
 // SysCatalogTable is a Kudu table that keeps track of the following
 // system information:
 //   * cluster id
@@ -262,6 +272,10 @@ class SysCatalogTable {
     return tablet_replica_;
   }
 
+  SimpleTableVisitor getSimpleTableVisitor() const {
+    return simpleTableLoader_;
+  }
+
  private:
   FRIEND_TEST(MasterTest, TestMasterMetadataConsistentDespiteFailures);
   DISALLOW_COPY_AND_ASSIGN(SysCatalogTable);
@@ -397,6 +411,8 @@ class SysCatalogTable {
   consensus::RaftPeerPB local_peer_pb_;
 
   scoped_refptr<Counter> oversized_write_requests_;
+
+  SimpleTableVisitor simpleTableLoader_;
 };
 
 } // namespace master

--- a/src/kudu/server/server_base.cc
+++ b/src/kudu/server/server_base.cc
@@ -619,7 +619,7 @@ Status ServerBase::Init() {
     s = fs_manager_->Open(&report, startup_path_handler_->read_instance_metadata_files_progress(),
                           startup_path_handler_->read_data_directories_progress());
   }
-  RETURN_NOT_OK_PREPEND(s, "Failed to load FS layout");
+  RETURN_NOT_OK_PREPEND(s, "hello Failed to load FS layout");
   RETURN_NOT_OK(report.LogAndCheckForFatalErrors());
   read_filesystem->Stop();
   RETURN_NOT_OK(InitAcls());

--- a/src/kudu/tools/master_rebuilder.h
+++ b/src/kudu/tools/master_rebuilder.h
@@ -110,6 +110,9 @@ class MasterRebuilder {
   // Write the syscatalog table based on the collated tablet server metadata.
   Status WriteSysCatalog();
 
+  // Update or write the syscatalog table based on the collated tablet server metadata.
+  Status UpsertSysCatalog();
+
   State state_;
 
   // Addresses of the tablet servers used for the reconstruction.
@@ -128,6 +131,5 @@ class MasterRebuilder {
 
   DISALLOW_COPY_AND_ASSIGN(MasterRebuilder);
 };
-
 } // namespace tools
 } // namespace kudu

--- a/src/kudu/tools/tool_action_master.cc
+++ b/src/kudu/tools/tool_action_master.cc
@@ -72,6 +72,7 @@ DECLARE_int64(timeout_ms);
 DECLARE_string(columns);
 DECLARE_string(fs_wal_dir);
 DECLARE_string(fs_data_dirs);
+DECLARE_string(tables);
 
 DEFINE_string(master_uuid, "", "Permanent UUID of the master. Only needed to disambiguate in case "
                                "of multiple masters with same RPC address");
@@ -880,6 +881,7 @@ unique_ptr<Mode> BuildMasterMode() {
         .AddOptionalParameter("fs_data_dirs")
         .AddOptionalParameter("fs_metadata_dir")
         .AddOptionalParameter("fs_wal_dir")
+        .AddOptionalParameter("tables")
         .Build();
     builder.AddAction(std::move(unsafe_rebuild));
   }


### PR DESCRIPTION
Current function unsafe_rebuild will get all tables's meta data
from tservers, and rebuild a new sys table. The cost is very
high when only part of tables got damaged.

This patch will rebuild master with configured tables. That
means if some tables meta data get damaged, it only needs to
repair these damaged tables meta data.

Change-Id: I45d812c8a16228ac937603872161969eb05136eb