### PR TITLE
KUDU-3371 [fs] Use RocksDB to store LBM metadata

### DIFF
--- a/src/kudu/benchmarks/CMakeLists.txt
+++ b/src/kudu/benchmarks/CMakeLists.txt
@@ -33,12 +33,14 @@ target_link_libraries(tpch
 add_executable(tpch1 tpch/tpch1.cc)
 target_link_libraries(tpch1
   ${KUDU_MIN_TEST_LIBS}
+  rocksdb
   tpch)
 
 # tpch_real_world
 add_executable(tpch_real_world tpch/tpch_real_world.cc)
 target_link_libraries(tpch_real_world
   ${KUDU_MIN_TEST_LIBS}
+  rocksdb
   tpch)
 
 # rle
@@ -56,5 +58,5 @@ if(NOT APPLE)
 endif()
 
 # Tests
-SET_KUDU_TEST_LINK_LIBS(tpch)
+SET_KUDU_TEST_LINK_LIBS(tpch rocksdb)
 ADD_KUDU_TEST(tpch/rpc_line_item_dao-test)

--- a/src/kudu/client/CMakeLists.txt
+++ b/src/kudu/client/CMakeLists.txt
@@ -274,7 +274,8 @@ endif()
 SET_KUDU_TEST_LINK_LIBS(
   itest_util
   kudu_client
-  mini_cluster)
+  mini_cluster
+  rocksdb)
 ADD_KUDU_TEST(client-test NUM_SHARDS 8 PROCESSORS 2
                           DATA_FILES ../scripts/first_argument.sh)
 ADD_KUDU_TEST(client-unittest)

--- a/src/kudu/consensus/CMakeLists.txt
+++ b/src/kudu/consensus/CMakeLists.txt
@@ -122,6 +122,7 @@ SET_KUDU_TEST_LINK_LIBS(
   consensus
   tserver_proto
   cfile
+  rocksdb
   tablet
   kudu_util)
 

--- a/src/kudu/fs/CMakeLists.txt
+++ b/src/kudu/fs/CMakeLists.txt
@@ -43,7 +43,8 @@ target_link_libraries(kudu_fs
   fs_proto
   kudu_util
   gutil
-  ranger_kms_client)
+  ranger_kms_client
+  rocksdb)
 
 add_library(kudu_fs_test_util
   log_block_manager-test-util.cc)
@@ -55,7 +56,7 @@ target_link_libraries(kudu_fs_test_util
   gutil)
 
 # Tests
-SET_KUDU_TEST_LINK_LIBS(kudu_fs kudu_fs_test_util)
+SET_KUDU_TEST_LINK_LIBS(kudu_fs kudu_fs_test_util rocksdb lz4 snappy)
 ADD_KUDU_TEST(block_manager-test)
 ADD_KUDU_TEST(block_manager-stress-test RUN_SERIAL true)
 ADD_KUDU_TEST(data_dirs-test)

--- a/src/kudu/fs/block_manager.h
+++ b/src/kudu/fs/block_manager.h
@@ -200,7 +200,7 @@ class BlockManager {
   // Lists the available block manager types.
   static std::vector<std::string> block_manager_types() {
 #if defined(__linux__)
-    return { "file", "log" };
+    return { "file", "log", "logr" };
 #else
     return { "file" };
 #endif
@@ -314,8 +314,8 @@ class BlockDeletionTransaction {
   // Deletes a group of blocks given the block IDs, the actual deletion will take
   // place after the last open reader or writer is closed for each block that needs
   // be to deleted. The 'deleted' out parameter will be set with the list of block
-  // IDs that were successfully deleted, regardless of the value of returned 'status'
-  // is OK or error.
+  // IDs that were successfully deleted if it's not nullptr, regardless of the value
+  // of returned 'status' is OK or error.
   //
   // Returns the first deletion failure that was seen, if any.
   virtual Status CommitDeletedBlocks(std::vector<BlockId>* deleted) = 0;

--- a/src/kudu/fs/data_dirs.cc
+++ b/src/kudu/fs/data_dirs.cc
@@ -287,7 +287,7 @@ int DataDirManager::max_dirs() const {
 }
 
 Status DataDirManager::PopulateDirectoryMaps(const vector<unique_ptr<Dir>>& dirs) {
-  if (opts_.dir_type == "log") {
+  if (opts_.dir_type == "log" || opts_.dir_type == "logr") {
     return DirManager::PopulateDirectoryMaps(dirs);
   }
   DCHECK_EQ("file", opts_.dir_type);

--- a/src/kudu/fs/dir_util.cc
+++ b/src/kudu/fs/dir_util.cc
@@ -163,7 +163,7 @@ Status DirInstanceMetadataFile::Create(const set<string>& all_uuids,
 
   // If we're initializing the log block manager, check that we support
   // hole-punching.
-  if (dir_type_ == "log") {
+  if (dir_type_ == "log" || dir_type_ == "logr") {
     RETURN_NOT_OK_FAIL_INSTANCE_PREPEND(CheckHolePunch(env_, dir_name),
                                         kHolePunchErrorMsg);
   }

--- a/src/kudu/fs/file_block_manager.h
+++ b/src/kudu/fs/file_block_manager.h
@@ -70,6 +70,10 @@ struct BlockManagerMetrics;
 // The file-backed block manager.
 class FileBlockManager : public BlockManager {
  public:
+  static std::string name() {
+    return "file";
+  }
+
   // Note: all objects passed as pointers should remain alive for the lifetime
   // of the block manager.
   FileBlockManager(Env* env,

--- a/src/kudu/fs/fs_manager-test.cc
+++ b/src/kudu/fs/fs_manager-test.cc
@@ -1056,7 +1056,7 @@ TEST_P(FsManagerTestBase, TestAddRemoveSpeculative) {
 }
 
 TEST_P(FsManagerTestBase, TestAddRemoveDataDirsFuzz) {
-  const int kNumAttempts = AllowSlowTests() ? 1000 : 100;
+  const int kNumAttempts = AllowSlowTests() ? 500 : 100;
 
   if (FLAGS_block_manager == "file") {
     LOG(INFO) << "Skipping test, file block manager not supported";

--- a/src/kudu/fs/fs_manager.cc
+++ b/src/kudu/fs/fs_manager.cc
@@ -79,7 +79,8 @@ TAG_FLAG(enable_data_block_fsync, unsafe);
 
 #if defined(__linux__)
 DEFINE_string(block_manager, "log", "Which block manager to use for storage. "
-              "Valid options are 'file' and 'log'. The file block manager is not suitable for "
+              "Valid options are 'file', 'log' and 'logr'. "
+              "The file block manager is not suitable for "
               "production use due to scaling limitations.");
 #else
 DEFINE_string(block_manager, "file", "Which block manager to use for storage. "
@@ -173,6 +174,7 @@ using kudu::fs::FsErrorManager;
 using kudu::fs::FileBlockManager;
 using kudu::fs::FsReport;
 using kudu::fs::LogBlockManagerNativeMeta;
+using kudu::fs::LogrBlockManager;
 using kudu::fs::ReadableBlock;
 using kudu::fs::UpdateInstanceBehavior;
 using kudu::fs::WritableBlock;
@@ -383,6 +385,9 @@ void FsManager::InitBlockManager() {
   } else if (opts_.block_manager_type == "log") {
     block_manager_.reset(new LogBlockManagerNativeMeta(
         env_, dd_manager_.get(), error_manager_.get(), opts_.file_cache, std::move(bm_opts)));
+  } else if (opts_.block_manager_type == "logr") {
+    block_manager_.reset(new LogrBlockManager(
+        env_, dd_manager_.get(), error_manager_.get(), opts_.file_cache, std::move(bm_opts)));
   } else {
     LOG(FATAL) << "Unknown block_manager_type: " << opts_.block_manager_type;
   }
@@ -559,7 +564,8 @@ Status FsManager::Open(FsReport* report, Timer* read_instance_metadata_files,
     }
     if (read_data_directories) {
       read_data_directories->Stop();
-      if (opts_.metric_entity && opts_.block_manager_type == "log") {
+      if (opts_.metric_entity && (opts_.block_manager_type == "log" ||
+                                  opts_.block_manager_type == "logr")) {
         METRIC_log_block_manager_containers_processing_time_startup.Instantiate(opts_.metric_entity,
             (read_data_directories->TimeElapsed()).ToMilliseconds());
       }

--- a/src/kudu/fs/fs_report.cc
+++ b/src/kudu/fs/fs_report.cc
@@ -253,6 +253,34 @@ LBMPartialRecordCheck::Entry::Entry(string c, int64_t o)
 }
 
 ///////////////////////////////////////////////////////////////////////////////
+// LBMPartialRdbRecordCheck
+///////////////////////////////////////////////////////////////////////////////
+
+void LBMPartialRdbRecordCheck::MergeFrom(
+    const LBMPartialRdbRecordCheck& other) {
+  MERGE_ENTRIES_FROM(other);
+}
+
+string LBMPartialRdbRecordCheck::ToString() const {
+  // Aggregate interesting stats from all of the entries.
+  int64_t partial_records_repaired = 0;
+  for (const auto& pr : entries) {
+    if (pr.repaired) {
+      partial_records_repaired++;
+    }
+  }
+
+  return Substitute("Total LBM partial rdb records: $0 ($1 repaired)\n",
+                    entries.size(), partial_records_repaired);
+}
+
+LBMPartialRdbRecordCheck::Entry::Entry(string c, string b)
+    : container(std::move(c)),
+      block_id(std::move(b)),
+      repaired(false) {
+}
+
+///////////////////////////////////////////////////////////////////////////////
 // FsReport::Stats
 ///////////////////////////////////////////////////////////////////////////////
 
@@ -301,6 +329,7 @@ void FsReport::MergeFrom(const FsReport& other) {
   MERGE_ONE_CHECK(malformed_record_check);
   MERGE_ONE_CHECK(misaligned_block_check);
   MERGE_ONE_CHECK(partial_record_check);
+  MERGE_ONE_CHECK(partial_rdb_record_check);
 
 #undef MERGE_ONE_CHECK
 }
@@ -329,6 +358,7 @@ string FsReport::ToString() const {
   TOSTRING_ONE_CHECK(malformed_record_check, "malformed LBM records");
   TOSTRING_ONE_CHECK(misaligned_block_check, "misaligned LBM blocks");
   TOSTRING_ONE_CHECK(partial_record_check, "partial LBM records");
+  TOSTRING_ONE_CHECK(partial_rdb_record_check, "partial LBM rdb records");
 
 #undef TOSTRING_ONE_CHECK
   return s;

--- a/src/kudu/fs/fs_report.h
+++ b/src/kudu/fs/fs_report.h
@@ -173,6 +173,27 @@ struct LBMPartialRecordCheck {
   std::vector<Entry> entries;
 };
 
+// Checks for partial LBM metadata records in RocksDB.
+//
+// TODO: check wether fatal and repairable
+// Error type: fatal and repairable (by removing the entries from RocksDB).
+struct LBMPartialRdbRecordCheck {
+
+  // Merges the contents of another check into this one.
+  void MergeFrom(const LBMPartialRdbRecordCheck& other);
+
+  // Returns a multi-line string representation of this check.
+  std::string ToString() const;
+
+  struct Entry {
+    Entry(std::string c, std::string b);
+    std::string container;
+    std::string block_id;;
+    bool repaired;
+  };
+  std::vector<Entry> entries;
+};
+
 // Results of a Kudu filesystem-wide check. The report contains general
 // statistics about the filesystem as well as a series of "checks" that
 // describe possible on-disk inconsistencies.
@@ -268,6 +289,7 @@ struct FsReport {
   std::optional<LBMMalformedRecordCheck> malformed_record_check;
   std::optional<LBMMisalignedBlockCheck> misaligned_block_check;
   std::optional<LBMPartialRecordCheck> partial_record_check;
+  std::optional<LBMPartialRdbRecordCheck> partial_rdb_record_check;
 };
 
 } // namespace fs

--- a/src/kudu/fs/log_block_manager-test-util.cc
+++ b/src/kudu/fs/log_block_manager-test-util.cc
@@ -28,19 +28,28 @@
 
 #include <gflags/gflags_declare.h>
 #include <glog/logging.h>
+#include <rocksdb/db.h>
+#include <rocksdb/iterator.h>
+#include <rocksdb/options.h>
+#include <rocksdb/slice.h>
+#include <rocksdb/status.h>
 
 #include "kudu/fs/block_id.h"
+#include "kudu/fs/data_dirs.h"
+#include "kudu/fs/dir_manager.h"
 #include "kudu/fs/fs.pb.h"
 #include "kudu/fs/log_block_manager.h"
 #include "kudu/gutil/integral_types.h"
 #include "kudu/gutil/strings/strcat.h"
 #include "kudu/gutil/strings/strip.h"
+#include "kudu/gutil/strings/substitute.h"
 #include "kudu/util/env.h"
 #include "kudu/util/path_util.h"
 #include "kudu/util/pb_util.h"
 #include "kudu/util/slice.h"
 #include "kudu/util/status.h"
 
+DECLARE_string(block_manager);
 DECLARE_uint64(log_container_max_size);
 
 namespace kudu {
@@ -52,49 +61,53 @@ using std::string;
 using std::vector;
 using std::unique_ptr;
 using std::unordered_map;
+using strings::Substitute;
 
-LBMCorruptor::LBMCorruptor(Env* env, vector<string> data_dirs, uint32_t rand_seed)
+LBMCorruptor::LBMCorruptor(Env* env, DataDirManager* dd_manager, uint32_t rand_seed)
     : env_(env),
-      data_dirs_(std::move(data_dirs)),
+      dd_manager_(dd_manager),
       rand_(rand_seed) {
-  CHECK_GT(data_dirs_.size(), 0);
+  CHECK_GT(dd_manager_->dirs().size(), 0);
 }
 
 Status LBMCorruptor::Init() {
   vector<Container> all_containers;
   vector<Container> full_containers;
 
-  for (const auto& dd : data_dirs_) {
+  for (const auto& dd : dd_manager_->dirs()) {
     vector<string> dd_files;
     unordered_map<string, Container> containers_by_name;
-    RETURN_NOT_OK(env_->GetChildren(dd, &dd_files));
+    RETURN_NOT_OK(env_->GetChildren(dd->dir(), &dd_files));
     for (const auto& f : dd_files) {
       // As we iterate over each file in the data directory, keep track of data
       // and metadata files, so that only containers with both will be included.
       string stripped;
       if (TryStripSuffixString(
           f, LogBlockManager::kContainerDataFileSuffix, &stripped)) {
+        containers_by_name[stripped].dir = dd->dir();
         containers_by_name[stripped].name = stripped;
-        containers_by_name[stripped].data_filename = JoinPathSegments(dd, f);
+        containers_by_name[stripped].data_filename = JoinPathSegments(dd->dir(), f);
       } else if (TryStripSuffixString(
           f, LogBlockManager::kContainerMetadataFileSuffix, &stripped)) {
+        containers_by_name[stripped].dir = dd->dir();
         containers_by_name[stripped].name = stripped;
-        containers_by_name[stripped].metadata_filename = JoinPathSegments(dd, f);
+        containers_by_name[stripped].metadata_filename = JoinPathSegments(dd->dir(), f);
       }
     }
 
     for (const auto& e : containers_by_name) {
       // Only include the container if both of its files were present.
-      if (!e.second.data_filename.empty() &&
-          !e.second.metadata_filename.empty()) {
-        all_containers.push_back(e.second);
+      if (!e.second.data_filename.empty()) {
+        if (FLAGS_block_manager == "logr" || !e.second.metadata_filename.empty()) {
+          all_containers.push_back(e.second);
 
-        // File size is an imprecise proxy for whether a container is full, but
-        // it should be good enough.
-        uint64_t data_file_size;
-        RETURN_NOT_OK(env_->GetFileSize(e.second.data_filename, &data_file_size));
-        if (data_file_size >= FLAGS_log_container_max_size) {
-          full_containers.push_back(e.second);
+          // File size is an imprecise proxy for whether a container is full, but
+          // it should be good enough.
+          uint64_t data_file_size;
+          RETURN_NOT_OK(env_->GetFileSize(e.second.data_filename, &data_file_size));
+          if (data_file_size >= FLAGS_log_container_max_size) {
+            full_containers.push_back(e.second);
+          }
         }
       }
     }
@@ -164,15 +177,29 @@ Status LBMCorruptor::AddUnpunchedBlockToFullContainer() {
 
   // Having written out the block, write both CREATE and DELETE metadata
   // records for it.
-  unique_ptr<WritablePBContainerFile> metadata_writer;
-  RETURN_NOT_OK(OpenMetadataWriter(*c, &metadata_writer));
   BlockId block_id(rand_.Next64());
-  RETURN_NOT_OK(AppendCreateRecord(metadata_writer.get(), block_id,
-                                   initial_data_size, block_length));
-  RETURN_NOT_OK(AppendDeleteRecord(metadata_writer.get(), block_id));
-
+  if (FLAGS_block_manager == "log") {
+    unique_ptr<WritablePBContainerFile> metadata_writer;
+    RETURN_NOT_OK(OpenMetadataWriter(*c, &metadata_writer));
+    RETURN_NOT_OK(
+        AppendCreateRecord(metadata_writer.get(), block_id, initial_data_size, block_length));
+      RETURN_NOT_OK(AppendDeleteRecord(metadata_writer.get(), block_id));
+      RETURN_NOT_OK(metadata_writer->Close());
+  } else {
+    Dir* pdir = nullptr;
+    for (const auto& dir : dd_manager_->dirs()) {
+      if (dir->dir() == c->dir) {
+        pdir = dir.get();
+        break;
+      }
+    }
+    CHECK(pdir);
+    RETURN_NOT_OK(AppendCreateRecord(pdir, c->name, block_id, initial_data_size, block_length));
+    RETURN_NOT_OK(AppendDeleteRecord(pdir, c->name, block_id));
+  }
   LOG(INFO) << "Added unpunched block to full container " << c->name;
-  return metadata_writer->Close();
+
+  return Status::OK();
 }
 
 Status LBMCorruptor::CreateIncompleteContainer() {
@@ -190,17 +217,18 @@ Status LBMCorruptor::CreateIncompleteContainer() {
   // 1. Empty data file but no metadata file.
   // 2. No data file but metadata file exists (and is up to a certain size).
   // 3. Empty data file and metadata file exists (and is up to a certain size).
-  int r = rand_.Uniform(3);
+  int max = (FLAGS_block_manager == "logr") ? 2 : 3;
+  int r = rand_.Uniform(max);
   RWFileOptions opts;
   opts.is_sensitive = true;
   if (r == 0) {
     RETURN_NOT_OK(env_->NewRWFile(opts, data_fname, &data_file));
   } else if (r == 1) {
-    RETURN_NOT_OK(env_->NewRWFile(opts, metadata_fname, &data_file));
+    RETURN_NOT_OK(env_->NewRWFile(opts, data_fname, &data_file));
+    RETURN_NOT_OK(env_->NewRWFile(opts, metadata_fname, &metadata_file));
   } else {
     CHECK_EQ(r, 2);
-    RETURN_NOT_OK(env_->NewRWFile(opts, data_fname, &data_file));
-    RETURN_NOT_OK(env_->NewRWFile(opts, metadata_fname, &data_file));
+    RETURN_NOT_OK(env_->NewRWFile(opts, metadata_fname, &metadata_file));
   }
 
   if (data_file) {
@@ -247,8 +275,19 @@ Status LBMCorruptor::AddMalformedRecordToContainer() {
   record.set_length(kBlockSize);
   record.set_timestamp_us(0);
 
+  Dir* pdir = nullptr;
   unique_ptr<WritablePBContainerFile> metadata_writer;
-  RETURN_NOT_OK(OpenMetadataWriter(*c, &metadata_writer));
+  if (FLAGS_block_manager == "logr") {
+    for (const auto& dir : dd_manager_->dirs()) {
+      if (dir->dir() == c->dir) {
+        pdir = dir.get();
+        break;
+      }
+    }
+    CHECK(pdir);
+  } else {
+    RETURN_NOT_OK(OpenMetadataWriter(*c, &metadata_writer));
+  }
 
   // Corrupt the record in some way. Kinds of malformed records (as per the
   // malformed record checking code in log_block_manager.cc):
@@ -258,10 +297,11 @@ Status LBMCorruptor::AddMalformedRecordToContainer() {
   // 2. Negative block offset.
   // 3. Negative block length.
   // 4. Offset + length > data file size.
-  // 5. Two CREATEs for same block ID.
+  // 5. log: Two CREATEs for same block ID.
   // 6. DELETE without first matching CREATE.
   // 7. Unrecognized op type.
-  int r = rand_.Uniform(8);
+  int max = (FLAGS_block_manager == "logr") ? 7 : 8;
+  int r = rand_.Uniform(max);
   if (r == 0) {
     record.clear_offset();
   } else if (r == 1) {
@@ -273,18 +313,30 @@ Status LBMCorruptor::AddMalformedRecordToContainer() {
   } else if (r == 4) {
     record.set_offset(kint64max / 2);
   } else if (r == 5) {
-    RETURN_NOT_OK(metadata_writer->Append(record));
-  } else if (r == 6) {
     record.clear_offset();
     record.clear_length();
     record.set_op_type(DELETE);
+  } else if (r == 6) {
+    record.set_op_type(UNKNOWN);
   } else {
     CHECK_EQ(r, 7);
-    record.set_op_type(UNKNOWN);
+    RETURN_NOT_OK(metadata_writer->Append(record));
+  }
+
+  if (FLAGS_block_manager == "logr") {
+    string buf;
+    record.SerializeToString(&buf);
+    rocksdb::WriteOptions options;
+    string tmp(c->name + "." + block_id.ToString());
+    rocksdb::Slice key(tmp);
+    rocksdb::Status s = pdir->rdb()->Put(options, key, rocksdb::Slice(buf));
+    CHECK_OK(FromRdbStatus(s));
+  } else {
+    RETURN_NOT_OK(metadata_writer->Append(record));
   }
 
   LOG(INFO) << "Added malformed record to container " << c->name;
-  return metadata_writer->Append(record);
+  return Status::OK();
 }
 
 Status LBMCorruptor::AddMisalignedBlockToContainer() {
@@ -341,13 +393,29 @@ Status LBMCorruptor::AddMisalignedBlockToContainer() {
   RETURN_NOT_OK(data_file->Close());
 
   // Having written out the block, write a corresponding metadata record.
-  unique_ptr<WritablePBContainerFile> metadata_writer;
-  RETURN_NOT_OK(OpenMetadataWriter(*c, &metadata_writer));
-  RETURN_NOT_OK(AppendCreateRecord(metadata_writer.get(), block_id,
-                                   block_offset, block_length));
+  if (FLAGS_block_manager == "logr") {
+    Dir* pdir = nullptr;
+    for (const auto& dir : dd_manager_->dirs()) {
+      if (dir->dir() == c->dir) {
+        pdir = dir.get();
+        break;
+      }
+    }
+    CHECK(pdir);
 
-  LOG(INFO) << "Added misaligned block to container " << c->name;
-  return metadata_writer->Close();
+    RETURN_NOT_OK(AppendCreateRecord(pdir, c->name, block_id,
+                                     block_offset, block_length));
+  } else {
+    unique_ptr<WritablePBContainerFile> metadata_writer;
+    RETURN_NOT_OK(OpenMetadataWriter(*c, &metadata_writer));
+    RETURN_NOT_OK(AppendCreateRecord(metadata_writer.get(), block_id,
+                                     block_offset, block_length));
+    RETURN_NOT_OK(metadata_writer->Close());
+  }
+
+  LOG(INFO) << Substitute("Added misaligned block $0 to container $1",
+                          block_id.ToString(), c->name);
+  return Status::OK();
 }
 
 Status LBMCorruptor::AddPartialRecordToContainer() {
@@ -355,15 +423,58 @@ Status LBMCorruptor::AddPartialRecordToContainer() {
   RETURN_NOT_OK(GetRandomContainer(ANY, &c));
 
   unique_ptr<WritablePBContainerFile> metadata_writer;
-  RETURN_NOT_OK(OpenMetadataWriter(*c, &metadata_writer));
+  Dir* pdir = nullptr;
+  if (FLAGS_block_manager == "logr") {
+    for (const auto& dir : dd_manager_->dirs()) {
+      if (dir->dir() == c->dir) {
+        pdir = dir.get();
+        break;
+      }
+    }
+    CHECK(pdir);
+    // Add a new good record to the container.
+    RETURN_NOT_OK(AppendCreateRecord(pdir, c->name, BlockId(rand_.Next64()),
+                                     0, 0));
+    // Corrupt the record by truncating one byte off the end of it.
+    bool has_metadata = false;
+    BlockRecordPB record;
+    rocksdb::Slice begin_key = c->name;
+    rocksdb::ReadOptions options;
+    std::unique_ptr<rocksdb::Iterator> it(
+        pdir->rdb()->NewIterator(options, pdir->rdb()->DefaultColumnFamily()));
+    it->Seek(begin_key);
+    if (it->Valid() && it->key().starts_with(begin_key)) {
+      if (!record.ParseFromArray(it->value().data(), it->value().size())) {
+        LOG(FATAL) << it->status().ToString();
+      }
+      has_metadata = true;
+    }
+    if (!it->status().ok()) {
+      LOG(FATAL) << it->status().ToString();
+    }
+    CHECK(has_metadata);
 
-  // Add a new good record to the container.
-  RETURN_NOT_OK(AppendCreateRecord(metadata_writer.get(),
-                                   BlockId(rand_.Next64()),
-                                   0, 0));
+    string tmp_key = c->name + "." + BlockId::FromPB(record.block_id()).ToString();
+    rocksdb::Slice key(tmp_key);
+    string value;
+    rocksdb::ReadOptions ropt;
+    rocksdb::Status s = pdir->rdb()->Get(ropt, key, &value);
+    if (!s.ok()) {
+      LOG(FATAL) << s.ToString();
+    }
 
-  // Corrupt the record by truncating one byte off the end of it.
-  {
+    value.substr(value.size() - 1);
+
+    rocksdb::WriteOptions wopt;
+    s = pdir->rdb()->Put(wopt, key, rocksdb::Slice(value));
+    CHECK_OK(FromRdbStatus(s));
+  } else {
+    RETURN_NOT_OK(OpenMetadataWriter(*c, &metadata_writer));
+    // Add a new good record to the container.
+    RETURN_NOT_OK(AppendCreateRecord(metadata_writer.get(),
+                                     BlockId(rand_.Next64()),
+                                     0, 0));
+    // Corrupt the record by truncating one byte off the end of it.
     RWFileOptions opts;
     opts.mode = Env::MUST_EXIST;
     opts.is_sensitive = true;
@@ -455,6 +566,32 @@ Status LBMCorruptor::AppendCreateRecord(WritablePBContainerFile* writer,
   return writer->Append(record);
 }
 
+Status LBMCorruptor::AppendCreateRecord(Dir* dir,
+                                        const string& id,
+                                        BlockId block_id,
+                                        int64_t block_offset,
+                                        int64_t block_length) {
+  BlockRecordPB record;
+  block_id.CopyToPB(record.mutable_block_id());
+  record.set_op_type(CREATE);
+  record.set_offset(block_offset);
+  record.set_length(block_length);
+  record.set_timestamp_us(0); // has no effect
+
+  string buf;
+  record.SerializeToString(&buf);
+  rocksdb::WriteOptions options;
+  string tmp(id + "." + block_id.ToString());
+  rocksdb::Slice key(tmp);
+//  LOG(INFO) << "Put: " << id << " " << key.ToString() << " " << key.size();
+  rocksdb::Status s = dir->rdb()->Put(options, key, rocksdb::Slice(buf));
+  if (!s.ok()) {
+    LOG(FATAL) << s.ToString();
+  }
+
+  return Status::OK();
+}
+
 Status LBMCorruptor::AppendDeleteRecord(WritablePBContainerFile* writer,
                                         BlockId block_id) {
   BlockRecordPB record;
@@ -462,6 +599,21 @@ Status LBMCorruptor::AppendDeleteRecord(WritablePBContainerFile* writer,
   record.set_op_type(DELETE);
   record.set_timestamp_us(0); // has no effect
   return writer->Append(record);
+}
+
+Status LBMCorruptor::AppendDeleteRecord(Dir* dir,
+                                        const std::string& id,
+                                        BlockId block_id) {
+  rocksdb::WriteOptions options;
+  string tmp(id + "." + block_id.ToString());
+  rocksdb::Slice key(tmp);
+//  LOG(INFO) << "Delete: " << id << " " << key.ToString() << " " << key.size();
+  rocksdb::Status s = dir->rdb()->Delete(options, key);
+  if (!s.ok()) {
+    LOG(FATAL) << s.ToString();
+  }
+
+  return Status::OK();
 }
 
 Status LBMCorruptor::PreallocateForBlock(RWFile* data_file,
@@ -494,8 +646,8 @@ Status LBMCorruptor::GetRandomContainer(FindContainerMode mode,
   return Status::OK();
 }
 
-const string& LBMCorruptor::GetRandomDataDir() const {
-  return data_dirs_[rand_.Uniform(data_dirs_.size())];
+string LBMCorruptor::GetRandomDataDir() const {
+  return dd_manager_->GetDirs()[rand_.Uniform(dd_manager_->GetDirs().size())];
 }
 
 } // namespace fs

--- a/src/kudu/integration-tests/CMakeLists.txt
+++ b/src/kudu/integration-tests/CMakeLists.txt
@@ -52,10 +52,11 @@ target_link_libraries(itest_util
   security_test_util)
 add_dependencies(itest_util
   kudu-master
-  kudu-tserver)
+  kudu-tserver
+  kudu)
 
 # Tests
-SET_KUDU_TEST_LINK_LIBS(itest_util gumbo-parser gumbo-query)
+SET_KUDU_TEST_LINK_LIBS(itest_util gumbo-parser gumbo-query rocksdb)
 ADD_KUDU_TEST(all_types-itest
   PROCESSORS 4
   NUM_SHARDS 8)

--- a/src/kudu/integration-tests/dense_node-itest.cc
+++ b/src/kudu/integration-tests/dense_node-itest.cc
@@ -22,6 +22,7 @@
 #include <memory>
 #include <ostream>
 #include <string>
+#include <tuple>
 #include <utility>
 #include <vector>
 
@@ -30,6 +31,7 @@
 #include <gtest/gtest.h>
 
 #include "kudu/client/schema.h"
+#include "kudu/fs/block_manager.h"
 #include "kudu/gutil/integral_types.h"
 #include "kudu/gutil/strings/substitute.h"
 #include "kudu/integration-tests/cluster_itest_util.h"
@@ -75,6 +77,7 @@ using client::KuduColumnSchema;
 using client::KuduSchema;
 using client::KuduSchemaBuilder;
 using cluster::ExternalMiniClusterOptions;
+using kudu::fs::BlockManager;
 using std::pair;
 using std::string;
 using std::unique_ptr;
@@ -83,10 +86,13 @@ using strings::Substitute;
 
 class DenseNodeTest :
   public ExternalMiniClusterITestBase,
-  public testing::WithParamInterface<bool> {
+  public testing::WithParamInterface<std::tuple<bool, string>> {
 };
 
-INSTANTIATE_TEST_SUITE_P(, DenseNodeTest, testing::Values(false, true));
+INSTANTIATE_TEST_SUITE_P(, DenseNodeTest,
+                         ::testing::Combine(
+                             ::testing::Bool(),
+                             ::testing::ValuesIn(BlockManager::block_manager_types())));
 
 // Integration test that simulates "dense" Kudu nodes.
 //
@@ -152,10 +158,14 @@ TEST_P(DenseNodeTest, RunTest) {
     opts.extra_master_flags.emplace_back("--never_fsync=false");
   }
 
-  if (GetParam()) {
+  if (std::get<0>(GetParam())) {
     opts.extra_master_flags.emplace_back("--encrypt_data_at_rest=true");
     opts.extra_tserver_flags.emplace_back("--encrypt_data_at_rest=true");
   }
+
+  FLAGS_block_manager = std::get<1>(GetParam());
+  opts.extra_master_flags.emplace_back(Substitute("--block_manager=$0", FLAGS_block_manager));
+  opts.extra_tserver_flags.emplace_back(Substitute("--block_manager=$0", FLAGS_block_manager));
 
   // With the amount of data we're going to write, we need to make sure the
   // tserver has enough time to start back up (startup is only considered to be
@@ -199,7 +209,7 @@ TEST_P(DenseNodeTest, RunTest) {
   // metrics are logged so that they're easier to find in the log output.
   vector<pair<string, int64_t>> metrics;
   vector<GaugePrototype<uint64>*> metric_prototypes;
-  if (FLAGS_block_manager == "log") {
+  if (FLAGS_block_manager == "log" || FLAGS_block_manager == "logr") {
     metric_prototypes = { &METRIC_log_block_manager_blocks_under_management,
                           &METRIC_log_block_manager_bytes_under_management,
                           &METRIC_log_block_manager_containers,

--- a/src/kudu/integration-tests/ts_recovery-itest.cc
+++ b/src/kudu/integration-tests/ts_recovery-itest.cc
@@ -236,7 +236,7 @@ TEST_F(TsRecoveryITest, TestTabletRecoveryAfterSegmentDelete) {
 // Test for KUDU-2202 that ensures that blocks not found in the FS layer but
 // that are referenced by a tablet will not be reused.
 TEST_P(TsRecoveryITest, TestNoBlockIDReuseIfMissingBlocks) {
-  if (GetParam() != "log") {
+  if (GetParam() != "log" && GetParam() != "logr") {
     LOG(INFO) << "Missing blocks is currently only supported by the log "
                  "block manager. Exiting early!";
     return;
@@ -309,7 +309,8 @@ TEST_P(TsRecoveryITest, TestNoBlockIDReuseIfMissingBlocks) {
     vector<string> children;
     ASSERT_OK(env_->GetChildren(data_dir, &children));
     for (const string& child : children) {
-      if (child != "." && child != ".." && child != fs::kInstanceMetadataFileName) {
+      if (child != "." && child != ".." &&
+          child != fs::kInstanceMetadataFileName && child != "rdb") {
         ASSERT_OK(env_->DeleteFile(JoinPathSegments(data_dir, child)));
       }
     }

--- a/src/kudu/server/CMakeLists.txt
+++ b/src/kudu/server/CMakeLists.txt
@@ -82,9 +82,12 @@ endif()
 SET_KUDU_TEST_LINK_LIBS(
   kudu_curl_util
   mini_kdc
+  rocksdb
+  lz4
   server_process
-  security_test_util)
+  security_test_util
+  snappy)
 ADD_KUDU_TEST(rpc_server-test)
 ADD_KUDU_TEST(webserver-test)
 
-SET_KUDU_TEST_LINK_LIBS(server_process)
+SET_KUDU_TEST_LINK_LIBS(server_process rocksdb snappy lz4)

--- a/src/kudu/tablet/compaction-test.cc
+++ b/src/kudu/tablet/compaction-test.cc
@@ -1385,7 +1385,7 @@ TEST_F(TestCompaction, TestCompactionFreesDiskSpace) {
 // Regression test for KUDU-1237, a bug in which empty flushes or compactions
 // would result in orphaning near-empty cfile blocks on the disk.
 TEST_F(TestCompaction, TestEmptyFlushDoesntLeakBlocks) {
-  if (FLAGS_block_manager != "log") {
+  if (FLAGS_block_manager != "log" && FLAGS_block_manager != "logr") {
     LOG(WARNING) << "Test requires the log block manager";
     GTEST_SKIP();
   }

--- a/src/kudu/tablet/tablet_metadata.cc
+++ b/src/kudu/tablet/tablet_metadata.cc
@@ -574,8 +574,7 @@ void TabletMetadata::DeleteOrphanedBlocks(const BlockIdContainer& blocks) {
   for (const BlockId& b : blocks) {
     transaction->AddDeletedBlock(b);
   }
-  vector<BlockId> deleted;
-  WARN_NOT_OK(transaction->CommitDeletedBlocks(&deleted),
+  WARN_NOT_OK(transaction->CommitDeletedBlocks(nullptr),
               "not all orphaned blocks were deleted");
 
   // Regardless of whether we deleted all the blocks or not, remove them from

--- a/src/kudu/tools/CMakeLists.txt
+++ b/src/kudu/tools/CMakeLists.txt
@@ -137,6 +137,7 @@ target_link_libraries(kudu
   log
   master
   mini_cluster
+  rocksdb
   tablet
   tool_proto
   transactions
@@ -193,7 +194,8 @@ ADD_KUDU_TEST(kudu-tool-test
   DATA_FILES testdata/sample-diagnostics-log.txt testdata/bad-diagnostics-log.txt
   DATA_FILES ../scripts/first_argument.sh)
 ADD_KUDU_TEST_DEPENDENCIES(kudu-tool-test
-  kudu)
+  kudu
+  rocksdb)
 ADD_KUDU_TEST(kudu-ts-cli-test)
 ADD_KUDU_TEST_DEPENDENCIES(kudu-ts-cli-test
   kudu)

--- a/src/kudu/tools/tool_test_util.cc
+++ b/src/kudu/tools/tool_test_util.cc
@@ -23,6 +23,7 @@
 #include <utility>
 #include <vector>
 
+#include <gflags/gflags.h>
 #include <glog/logging.h>
 
 #include "kudu/gutil/strings/split.h"
@@ -36,6 +37,8 @@ using std::string;
 using std::vector;
 using strings::Split;
 using strings::Substitute;
+
+DECLARE_string(block_manager);
 
 namespace kudu {
 namespace tools {
@@ -67,6 +70,8 @@ Status RunKuduTool(const vector<string>& args, string* out, string* err,
   // level higher than 0, so it's necessary to override it on the client
   // side as well to allow clients to accept and verify TLS certificates.
   total_args.emplace_back("--openssl_security_level_override=0");
+
+  total_args.emplace_back(Substitute("--block_manager=$0", FLAGS_block_manager));
 
   total_args.insert(total_args.end(), args.begin(), args.end());
   return Subprocess::Call(total_args, in, out, err, std::move(env_vars));

--- a/src/kudu/tserver/tablet_server-test.cc
+++ b/src/kudu/tserver/tablet_server-test.cc
@@ -938,7 +938,8 @@ TEST_F(TabletServerStartupWebPageTest, TestLogBlockContainerMetrics) {
   // Validate populated metrics in case of zero containers during startup.
   ASSERT_OK(c.FetchURL(Substitute("http://$0/metrics", addr), &buf));
   string raw = buf.ToString();
-  if (mini_server_->options()->fs_opts.block_manager_type == "log") {
+  if (mini_server_->options()->fs_opts.block_manager_type == "log" ||
+      mini_server_->options()->fs_opts.block_manager_type == "logr") {
     ASSERT_STR_MATCHES(raw, "log_block_manager_total_containers_startup\",\n[ ]+\"value\": 0");
     ASSERT_STR_MATCHES(raw, "log_block_manager_processed_containers_startup\",\n[ ]+\"value\": 0");
     // Since we open each directory and read all the contents, the time taken might not be
@@ -3929,7 +3930,7 @@ TEST_F(TabletServerTest, TestDeleteTablet) {
     METRIC_log_block_manager_blocks_under_management.Instantiate(
         mini_server_->server()->metric_entity(), 0);
   const int block_count_before_flush = ondisk->value();
-  if (FLAGS_block_manager == "log") {
+  if (FLAGS_block_manager == "log" || FLAGS_block_manager == "logr") {
     ASSERT_EQ(block_count_before_flush, 0);
   }
 
@@ -3940,7 +3941,7 @@ TEST_F(TabletServerTest, TestDeleteTablet) {
   NO_FATALS(InsertTestRowsRemote(2, 1));
 
   const int block_count_after_flush = ondisk->value();
-  if (FLAGS_block_manager == "log") {
+  if (FLAGS_block_manager == "log" || FLAGS_block_manager == "logr") {
     ASSERT_GT(block_count_after_flush, block_count_before_flush);
   }
 
@@ -3979,7 +3980,7 @@ TEST_F(TabletServerTest, TestDeleteTablet) {
 
   // Verify data was actually removed.
   const int block_count_after_delete = ondisk->value();
-  if (FLAGS_block_manager == "log") {
+  if (FLAGS_block_manager == "log" || FLAGS_block_manager == "logr") {
     ASSERT_EQ(block_count_after_delete, 0);
   }
 

--- a/src/kudu/util/CMakeLists.txt
+++ b/src/kudu/util/CMakeLists.txt
@@ -607,12 +607,14 @@ endif()
 #######################################
 # util/compression tests
 #######################################
-ADD_KUDU_TEST(compression/compression-test)
 if(NOT NO_TESTS)
-  target_link_libraries(compression-test
-    cfile
-    kudu_util_compression)
+  SET_KUDU_TEST_LINK_LIBS(
+          cfile
+          kudu_util_compression
+          rocksdb
+          lz4)
 endif()
+ADD_KUDU_TEST(compression/compression-test)
 
 #######################################
 # curl_util-test


### PR DESCRIPTION
Since LogBlockContainer store block records sequentially in metadata file, the live blocks maybe in a very low ratio, and it cause disk space wasting and long time bootstrap.

This patch use RocksDB to store LBM metadata, a new item will be Put() into RocksDB when a new block created in LBM, and the item will be Delete()d from RocksDB when the block removed from LBM. Data in RocksDB can be maintained in RocksDB itself, i.e. deleted items will be GCed so doesn't need rewriting as how we do it in current LBM.

The implemention also reuse most logic of LBM, the main difference is store Block records metadata in RocksDB.
1. Make LogBlockManager as a super class
2. The former LBM that stores metadata in a append only file, is separeted from LBM and specified a new name LogfBlockManager. Its behavior has no change.
3. Introduce a new class LogrBlockManager that stores metadata in RocksDB, the main idea: a. Create container Data file is created as before, metadata is stored in keys prefixed by the container's id, append the block id, e.g. <container_id>.<block_id>. Make sure there is no such keys in RocksDB before this container created. b. Open container Make sure the data file is healthy. c. Deconstruct container If the container is dead (full and no live blocks), remove the data file, and clean up keys prefixed by the container's id. d. Load container (by ProcessRecords()) Iterate the RocksDB in the key range [<container_id>, <next_container_id>), only live block records will be populated, we can use them as before. e. Create blocks in a container Put() serialized BlockRecordPB records into RocksDB in batch, keys are in form of '<container_id>.<block_id>' as mentioned above. f. Remove blocks from a container Contruct the keys by container's id and block's id, Delete() them from RocksDB in batch.

4. Some refactors, such as create and delete blocks in batch to reduce lock consult times.

This patch contains the following changes:
- Adds a new block manager type named 'logr', it use RocksDB to store LBM metadata, it is also specified by flag '--block_manager'.
- block_manager-test supports to test LogrBlockManager
- block_manager-stress-test supports to test LogrBlockManager
- log_block_manager-test supports to test LogrBlockManager
- tablet_server-test supports to test LogrBlockManager
- dense_node-itest supports to test LogrBlockManager
- kudu-tool-test supports to test LogrBlockManager

It's optional to use RocksDB, we can use the former LBM as before, we can introduce more tools to convert data between the two implemention in the future.

The optimization is obvious as shown in JIRA KUDU-3371, it shows that reopen staged reduced upto 90% time cost.

Change-Id: Ie72f6914eb5653a9c034766c6cd3741a8340711f