### PR TITLE
fix: set the result block to the decompressed data

### DIFF
--- a/src/kudu/cfile/cfile_reader.cc
+++ b/src/kudu/cfile/cfile_reader.cc
@@ -546,7 +546,7 @@ Status CFileReader::ReadBlock(const IOContext* io_context,
     scratch.Swap(&decompressed_scratch);
 
     // Set the result block to our decompressed data.
-    block = Slice(buf, uncompressed_size);
+    block = scratch.as_slice();
   }
 
   // It's possible that one of the TryAllocateFromCache() calls above


### PR DESCRIPTION
I mean, this is a bug.