### PR TITLE
Develocity integration for java client

### DIFF
--- a/java/settings.gradle
+++ b/java/settings.gradle
@@ -18,6 +18,11 @@
 // This file contains the configuration of the project hierarchy.
 // Mainly we just define what subprojects are in the build.
 
+plugins {
+    id 'com.gradle.develocity' version '3.17.4'
+    id 'com.gradle.common-custom-user-data-gradle-plugin' version '2.0.1'
+}
+
 rootProject.name = "kudu-parent"
 include "kudu-backup"
 include "kudu-backup-common"
@@ -30,3 +35,29 @@ include "kudu-spark"
 include "kudu-spark-tools"
 include "kudu-subprocess"
 include "kudu-test-utils"
+
+def isCI = System.getenv('CI') != null // adjust to your CI provider
+
+develocity {
+    server = 'https://ge.apache.org'
+    allowUntrustedServer = false
+
+    buildScan {
+        uploadInBackground = !isCI
+        publishing.onlyIf { it.isAuthenticated() }
+        obfuscation {
+            ipAddresses { addresses -> addresses.collect { address -> "0.0.0.0"} }
+        }
+    }
+}
+
+buildCache {
+    local {
+        enabled = true
+    }
+
+    remote(develocity.buildCache) {
+        enabled = false
+        push = isCI
+    }
+}


### PR DESCRIPTION
@martongreber, it was nice meeting you at Community over Code today. This PR will enable you to publish Build Scans to [ge.apache.org](https://ge.apache.org/) as discussed (for the Java build).

### Description

This PR publishes a build scan for every CI and local build from an authenticated Apache committer. The build will not fail if publishing fails. Remote caching was left disabled on this PR by design so that the build will not be affected by this change. 

The build scans of the Apache Kudu Java project are published to the Develocity instance at [ge.apache.org](https://ge.apache.org/), hosted by the Apache Software Foundation and run in partnership between the ASF and Gradle. This Develocity instance has all features and extensions enabled and is freely available for use by the Apache Kudu Java project and all other Apache projects.

On this Develocity instance, Apache Kudu java will have access not only to all of the published build scans but other aggregate data features such as:

- Dashboards to view all historical build scans, along with performance trends over time
- Build failure analytics for enhanced investigation and diagnosis of build failures
- Test failure analytics to better understand trends and causes around slow, failing, and flaky tests

Please let me know if there are any questions about the value of Develocity or the changes in this pull request, and I’d be happy to address them.

Note: I couldn't find any CI configuration, nor could I find the Apache Kudu project on https://ci-builds.apache.org/, but I'd be happy to help you configure the CI you are using with access to [ge.apache.org](https://ge.apache.org/).
