### PR TITLE
tablet: fix 'occured' / 'compelte' typos in row_op error-check doc

### DIFF
--- a/src/kudu/tablet/row_op.h
+++ b/src/kudu/tablet/row_op.h
@@ -102,7 +102,7 @@ struct RowOp {
   // True if an ignore op was ignored due to an error.
   bool error_ignored = false;
 
-  // True if this op has any error occured and failed to compelte this op.
+  // True if this op has any error occurred and failed to complete this op.
   bool failed = false;
 
   // The RowSet in which this op's key has been found present and alive.


### PR DESCRIPTION
Inline comment in `src/kudu/tablet/row_op.h:105` read `True if this op has any error occured and failed to compelte this op` — two typos on one line. Fixed to `has any error occurred and failed to complete this op`. Doc-only change.